### PR TITLE
Configure strict token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ service using token-based authentication.
 
 ## Configuration
 
+### Auth endpoint
+
 The API helpers need to know the endpoint for the G5 auth server to use when
 validating tokens. This may be configured in one of several ways:
 
@@ -51,6 +53,30 @@ validating tokens. This may be configured in one of several ways:
     config.endpoint = 'https://dev-auth.g5search.com'
   end
   ```
+
+### Strict token validation
+
+If your API supports session-based authentication through
+[devise_g5_authenticatable](https://github.com/G5/devise_g5_authenticatable),
+then you have the option of toggling strict token validation.
+
+If strict token validation is disabled (the default), then token validation
+will be bypassed if there is already an authenticated user in warden. This
+is fast, but it means that users with revoked or expired access tokens can
+still access your API as long as the local session remains active.
+
+```ruby
+G5AuthenticatableApi.strict_token_validation = false
+```
+
+If strict token validation is enabled, then the session user's access token
+will be periodically re-validated. Access to your API will be limited
+to users with active access tokens, but there is a performance penalty
+for this level of security.
+
+```ruby
+G5AuthenticatableApi.strict_token_validation = true
+```
 
 ## Usage
 

--- a/g5_authenticatable_api.gemspec
+++ b/g5_authenticatable_api.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rack'
   spec.add_dependency 'g5_authentication_client', '~> 0.2'
+  spec.add_dependency 'activesupport', '>= 3.2'
 end

--- a/lib/g5_authenticatable_api.rb
+++ b/lib/g5_authenticatable_api.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'active_support/core_ext/module/attribute_accessors'
+
 require 'g5_authenticatable_api/version'
 require 'g5_authenticatable_api/helpers/grape'
 require 'g5_authenticatable_api/railtie' if defined?(Rails)
@@ -5,5 +8,9 @@ require 'g5_authenticatable_api/railtie' if defined?(Rails)
 require 'g5_authentication_client'
 
 module G5AuthenticatableApi
-  # Your code goes here...
+  # When enabled, strict token validation will validate the session user's
+  # access_token against the auth server for every request (if there is
+  # an existing session in warden). Disabled by default.
+  @@strict_token_validation = false
+  mattr_accessor :strict_token_validation
 end

--- a/lib/g5_authenticatable_api/token_validator.rb
+++ b/lib/g5_authenticatable_api/token_validator.rb
@@ -10,7 +10,7 @@ module G5AuthenticatableApi
 
     def validate!
       begin
-        auth_client.token_info
+        auth_client.token_info unless skip_validation?
       rescue StandardError => @error
         raise error
       end
@@ -65,6 +65,10 @@ module G5AuthenticatableApi
         parts = @headers['Authorization'].match(/Bearer (?<access_token>\S+)/)
         parts['access_token']
       end
+    end
+
+    def skip_validation?
+      @warden.try(:user) && !G5AuthenticatableApi.strict_token_validation
     end
   end
 end

--- a/spec/support/shared_examples/warden_authenticatable_api.rb
+++ b/spec/support/shared_examples/warden_authenticatable_api.rb
@@ -8,7 +8,28 @@ shared_examples_for 'a warden authenticatable api' do
     before { login_as(user, scope: :user) }
     after { logout }
 
-    include_examples 'token validation'
+    context 'when strict token validation is enabled' do
+      before do
+        G5AuthenticatableApi.strict_token_validation = true
+      end
+
+      include_examples 'token validation'
+    end
+
+    context 'when strict token validation is disabled' do
+      before do
+        G5AuthenticatableApi.strict_token_validation = false
+        subject
+      end
+
+      it 'should be successful' do
+        expect(response).to be_success
+      end
+
+      it 'should not validate the token against the auth server' do
+        expect(a_request(:get, 'auth.g5search.com/oauth/token/info')).to_not have_been_made
+      end
+    end
   end
 
   context 'when user is not authenticated' do


### PR DESCRIPTION
Introduces the `G5Authenticatable.strict_token_validation` configuration option to toggle token validation logic when there is already an authenticated user.