### PR TITLE
handling "AUTHORIZATION" header

### DIFF
--- a/lib/g5_authenticatable_api/token_validator.rb
+++ b/lib/g5_authenticatable_api/token_validator.rb
@@ -61,14 +61,18 @@ module G5AuthenticatableApi
     end
 
     def extract_token_from_header
-      if @headers['Authorization']
-        parts = @headers['Authorization'].match(/Bearer (?<access_token>\S+)/)
+      if authorization_header
+        parts = authorization_header.match(/Bearer (?<access_token>\S+)/)
         parts['access_token']
       end
     end
 
     def skip_validation?
       @warden.try(:user) && !G5AuthenticatableApi.strict_token_validation
+    end
+
+    def authorization_header
+      @headers['Authorization'] || @headers['AUTHORIZATION']
     end
   end
 end

--- a/lib/g5_authenticatable_api/version.rb
+++ b/lib/g5_authenticatable_api/version.rb
@@ -1,3 +1,3 @@
 module G5AuthenticatableApi
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/spec/lib/g5_authenticatable_api/token_validator_spec.rb
+++ b/spec/lib/g5_authenticatable_api/token_validator_spec.rb
@@ -22,6 +22,15 @@ describe G5AuthenticatableApi::TokenValidator do
       end
     end
 
+    context 'with all caps authorization key' do
+      let(:headers) { {'AUTHORIZATION' => "Bearer #{token_value}"} }
+      let(:params) {}
+
+      it 'should extract the token value from the header' do
+        expect(access_token).to eq(token_value)
+      end
+    end
+
     context 'with auth param' do
       let(:params) { {'access_token' => token_value} }
       let(:headers) {}


### PR DESCRIPTION
We're seeing requests come in from httparty and other REST clients with an authorization header key of "AUTHORIZATION" instead of "Authorization".

This will allow both.